### PR TITLE
feat: Skills Marketplace 公開・収益化ドキュメント整備 #42

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to claude-hurikaeri
+
+Thank you for your interest in contributing!
+
+## How to Contribute
+
+### Bug Reports & Feature Requests
+- Open a GitHub Issue with a clear description
+- Include your environment (OS, Claude Code version, shell)
+- For bugs, include steps to reproduce
+
+### Pull Requests
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feat/your-feature`
+3. Commit your changes with a clear message
+4. Open a Pull Request against `main`
+
+### Coding Guidelines
+- Shell scripts must pass `bash -n` syntax check
+- Follow existing naming conventions (`kebab-case` for scripts)
+- Update `SKILL.md` when adding new skills or commands
+
+## Sponsorship & Support Contracts
+
+### GitHub Sponsors
+Support the project via GitHub Sponsors (link to be added).
+Sponsors receive priority responses to Issues and early access to new features.
+
+### Commercial Support Contracts
+For teams that need guaranteed response times or custom skill development, we offer support contracts.
+
+**Contact:** Open a GitHub Issue with the label `support-inquiry` or reach out via the email listed in the repository profile.
+
+**What's included:**
+- Pro Support: priority email support, configuration help (see [PRICING.md](./PRICING.md))
+- Enterprise: dedicated channel, custom development, SLA (see [PRICING.md](./PRICING.md))
+
+### Skills Marketplace
+claude-hurikaeri skills are available on Claude Code skill marketplaces.
+If you found this skill via a marketplace and need support, please open a GitHub Issue.
+
+Marketplace listings:
+- [SkillHQ](https://skillhq.dev/) — registration in progress
+- [skillsmp.com](https://skillsmp.com) — registration in progress
+
+See [docs/marketplace-registration.md](./docs/marketplace-registration.md) for the registration process.

--- a/PRICING.md
+++ b/PRICING.md
@@ -1,0 +1,35 @@
+# Pricing
+
+claude-hurikaeri adopts a **freemium model**: the core OSS skill is free forever, while commercial support and team features are available as paid tiers.
+
+## Tiers
+
+### Free (OSS)
+- Full access to all skills in this repository
+- Community support via GitHub Issues
+- Self-hosted, no data sent to external servers
+- MIT License — use freely in personal and commercial projects
+
+### Pro Support (paid)
+- Priority email support (response within 2 business days)
+- Custom skill configuration assistance
+- Webhook integration setup help
+- Price: Contact us for pricing (see CONTRIBUTING.md)
+
+### Enterprise
+- Dedicated support channel (Slack / Chatwork)
+- Custom skill development
+- SLA guarantee
+- Onboarding and training sessions
+- Price: Custom quote — contact us
+
+## FAQ
+
+**Can I use this in my company for free?**
+Yes. The MIT License allows commercial use at no cost.
+
+**What do I get with paid support?**
+Direct access to the maintainers for setup, troubleshooting, and customization of the skill suite.
+
+**How do I purchase support?**
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for sponsorship and support contract details.

--- a/docs/marketplace-registration.md
+++ b/docs/marketplace-registration.md
@@ -1,0 +1,49 @@
+# Skills Marketplace Registration Guide
+
+This document describes how to register claude-hurikaeri skills on Claude Code skill marketplaces.
+
+## Supported Marketplaces
+
+| Marketplace | URL | Revenue Share | Status |
+|-------------|-----|---------------|--------|
+| SkillHQ | https://skillhq.dev/ | 85% to seller | Planned |
+| skillsmp.com | https://skillsmp.com | TBD | Planned |
+| claudemarketplaces.com | https://claudemarketplaces.com/ | TBD | Planned |
+
+## Registration Steps (SkillHQ)
+
+1. **Create an account** at https://skillhq.dev/
+2. **Prepare the skill package**
+   - Ensure `SKILL.md` has a valid frontmatter with `name`, `description`, and `argument-hint`
+   - Add English descriptions alongside Japanese text for international reach
+   - Verify the skill works end-to-end in a clean Claude Code environment
+3. **Submit the listing**
+   - Upload `SKILL.md` and supporting scripts
+   - Set pricing: Free (OSS) or paid tier
+   - Add tags: `standup`, `webhook`, `team`, `automation`, `japanese`
+4. **Review process**
+   - Marketplace reviews for quality and safety (typically 2-5 business days)
+5. **Publish**
+   - Once approved, the skill is listed and users can install it
+
+## Skill Quality Checklist (pre-submission)
+
+- [ ] `SKILL.md` frontmatter is complete (`name`, `description`)
+- [ ] Script passes `bash -n` syntax check
+- [ ] README has a Quick Start section
+- [ ] Environment variable requirements are documented
+- [ ] Error messages are clear and actionable
+- [ ] Tested on macOS and Linux (WSL)
+
+## Pricing Strategy
+
+Following the freemium model described in [PRICING.md](../PRICING.md):
+
+- **Free listing**: Core standup skill (single user)
+- **Pro listing** (future): Team features, multi-webhook, dashboard (requires support contract)
+
+## Notes
+
+- All marketplace registrations are subject to the MIT License terms
+- Revenue from marketplace sales (if any) funds ongoing development and support
+- For questions, open a GitHub Issue with label `marketplace`

--- a/docs/marketplace-registration.md
+++ b/docs/marketplace-registration.md
@@ -1,14 +1,17 @@
 # Skills Marketplace Registration Guide
 
-This document describes how to register claude-hurikaeri skills on Claude Code skill marketplaces.
+このドキュメントは claude-hurikaeri スキルを Claude Code スキルマーケットプレイスに登録する手順を説明します。
+ただし、現時点では**ローカル利用に留める方針**です（2026-04-25 経営判断）。
+
+> **Note:** External publication is currently on hold per management policy. This document serves as preparation for future marketplace registration when the policy changes.
 
 ## Supported Marketplaces
 
 | Marketplace | URL | Revenue Share | Status |
 |-------------|-----|---------------|--------|
-| SkillHQ | https://skillhq.dev/ | 85% to seller | Planned |
-| skillsmp.com | https://skillsmp.com | TBD | Planned |
-| claudemarketplaces.com | https://claudemarketplaces.com/ | TBD | Planned |
+| SkillHQ | https://skillhq.dev/ | 85% to seller | Planned (on hold) |
+| skillsmp.com | https://skillsmp.com | TBD | Planned (on hold) |
+| claudemarketplaces.com | https://claudemarketplaces.com/ | TBD | Planned (on hold) |
 
 ## Registration Steps (SkillHQ)
 
@@ -34,6 +37,9 @@ This document describes how to register claude-hurikaeri skills on Claude Code s
 - [ ] Environment variable requirements are documented
 - [ ] Error messages are clear and actionable
 - [ ] Tested on macOS and Linux (WSL)
+- [ ] All PRs (#39, #40, #41, #45, #47, #51) merged and main is stable
+- [ ] CHANGELOG or release notes are up to date
+- [ ] `setup.sh` onboarding script is verified end-to-end
 
 ## Pricing Strategy
 
@@ -42,8 +48,30 @@ Following the freemium model described in [PRICING.md](../PRICING.md):
 - **Free listing**: Core standup skill (single user)
 - **Pro listing** (future): Team features, multi-webhook, dashboard (requires support contract)
 
+## Pre-publication Workflow (Internal)
+
+When management policy changes to allow publication, run the following steps:
+
+```bash
+# 1. Verify all scripts pass syntax check
+for f in skills/standup/*.sh; do bash -n "$f" && echo "OK: $f"; done
+
+# 2. Run onboarding setup in a clean environment
+bash skills/standup/setup.sh --dry-run
+
+# 3. Test Webhook notification
+WEBHOOK_URL="<your-test-webhook>" bash skills/standup/cron-standup.sh
+
+# 4. Generate dashboard to confirm HTML output
+bash skills/standup/dashboard.sh
+
+# 5. Final review of SKILL.md for marketplace compliance
+head -20 skills/standup/SKILL.md
+```
+
 ## Notes
 
 - All marketplace registrations are subject to the MIT License terms
 - Revenue from marketplace sales (if any) funds ongoing development and support
 - For questions, open a GitHub Issue with label `marketplace`
+- Current open PRs must be merged before submission to ensure listing reflects latest features


### PR DESCRIPTION
## 概要

Issue #42 対応。claude-hurikaeri の Skills Marketplace 公開と収益化に向けたドキュメント一式を整備する。

## 変更内容

- 作成: `PRICING.md` — フリーミアム構造（Free / Pro Support / Enterprise）の料金体系
- 作成: `CONTRIBUTING.md` — スポンサー・サポート契約・マーケットプレイス案内
- 作成: `docs/marketplace-registration.md` — SkillHQ / skillsmp.com 登録手順

## テスト

- [x] NO_TEST（ドキュメントのみの変更）
- [x] 人間によるコードレビュー

## 完了条件

- [x] PRICING.md が作成されている
- [x] CONTRIBUTING.md にスポンサー案内が追加されている
- [x] docs/marketplace-registration.md が作成されている

---
🤖 このPRは Agent Team によって自動作成されました