### PR TITLE
feat: Chatwork API v2 Webhook 通知対応 #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Claude Code で以下のように呼び出します：
 | `--summary weekly\|monthly` | 週次・月次サマリーを表示 |
 | `--export html` | HTML ファイルとしてエクスポート |
 | `--notify` | Slack/Discord Webhook に送信 |
+| `--notify chatwork` | Chatwork API v2 でルームに送信 |
 | `--template <path>` | カスタムテンプレートを使用 |
 
 ### 前提条件
@@ -75,6 +76,30 @@ Claude Code で以下のように呼び出します：
 cd claude-hurikaeri
 git pull
 cp -r skills/standup ~/.claude/skills/standup
+```
+
+## Chatwork 連携
+
+Chatwork へのスタンドアップ通知を設定するには、以下の環境変数を設定してください。
+
+```bash
+# Chatwork API トークン（Chatwork の「サービス連携」→「API トークン」で取得）
+export STANDUP_CHATWORK_TOKEN="your_api_token"
+
+# 送信先ルーム ID（URL の #!rid の後の数字）
+export STANDUP_CHATWORK_ROOM_ID="123456"
+```
+
+設定後、`--notify chatwork` オプションで通知できます：
+
+```bash
+/standup evening --notify chatwork
+```
+
+スクリプトを直接呼び出すこともできます：
+
+```bash
+skills/standup/chatwork-notify.sh "レポートテキスト"
 ```
 
 ## セキュリティ上の注意

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -9,7 +9,8 @@ description: >
   Supports --export html option to export the report as an HTML file.
   Supports --template option to customize the report format with a Markdown template.
   Supports --notify option to post the report to Slack/Discord via Webhook URL.
-argument-hint: "[morning|evening] [hours] [repo_path1 repo_path2 ...] [--save] [--export html] [--open] [--notify] [--search <keyword>] [--summary weekly|monthly] [--template <path>]"
+  Supports --notify chatwork option to post the report to Chatwork via API v2.
+argument-hint: "[morning|evening] [hours] [repo_path1 repo_path2 ...] [--save] [--export html] [--open] [--notify [chatwork]] [--search <keyword>] [--summary weekly|monthly] [--template <path>]"
 ---
 
 # Standup Meeting Skill（朝会・夕会）
@@ -38,6 +39,7 @@ argument-hint: "[morning|evening] [hours] [repo_path1 repo_path2 ...] [--save] [
 - `--export html` → レポート生成後に HTML ファイルとしてエクスポートする
 - `--open` → エクスポート後にブラウザで自動オープンする（`--export html` と併用）
 - `--notify` → レポート完了後に Slack/Discord Webhook に投稿する
+- `--notify chatwork` → レポート完了後に Chatwork API v2 で指定ルームに投稿する（環境変数 `STANDUP_CHATWORK_TOKEN` と `STANDUP_CHATWORK_ROOM_ID` が必要）
 - `--save` → スタンドアップレポートを `~/.standup-history/YYYY-MM-DD-morning-<repo>.json` または `~/.standup-history/YYYY-MM-DD-evening-<repo>.json` に保存する（`~` はそのユーザーの HOME ディレクトリ）
 - `--search <keyword>` → 過去のスタンドアップ履歴からキーワード検索して結果を表示する（朝会・夕会は実施しない）
 - `--summary weekly` → 過去7日分のスタンドアップ履歴を週次サマリーとして集計・表示する（朝会・夕会は実施しない）
@@ -706,6 +708,52 @@ grep -q '.standup-config.json' .gitignore || echo '.standup-config.json' >> .git
 - Webhook URL は秘密情報です。リポジトリに平文でコミットしないでください
 - `.standup-config.json` は `.gitignore` に追加してください（このリポジトリでは設定済み）
 - 万一 Webhook URL が漏洩した場合は、即座に Slack/Discord 側でトークンを無効化してください
+
+## Chatwork 通知の設定
+
+`--notify chatwork` オプションを使用する場合、以下の環境変数を設定してください。
+
+### 環境変数
+
+```bash
+export STANDUP_CHATWORK_TOKEN="your_chatwork_api_token"
+export STANDUP_CHATWORK_ROOM_ID="your_room_id"
+```
+
+### API トークンの取得方法
+
+1. Chatwork にログインする
+2. 右上のアカウント名 → 「サービス連携」をクリックする
+3. 「API トークン」セクションで「発行する」をクリックする
+4. 表示されたトークンをコピーして `STANDUP_CHATWORK_TOKEN` に設定する
+
+### ルーム ID の確認方法
+
+Chatwork のチャット URL に含まれる数字がルーム ID です。
+例: `https://www.chatwork.com/#!rid123456` → ルーム ID は `123456`
+
+### 使用例
+
+```bash
+export STANDUP_CHATWORK_TOKEN="abc123..."
+export STANDUP_CHATWORK_ROOM_ID="123456"
+
+# Chatwork に通知する
+/standup evening --notify chatwork
+
+# 直接スクリプトを呼び出す場合
+skills/standup/chatwork-notify.sh "本日のスタンドアップレポート..."
+```
+
+### オプション環境変数
+
+```bash
+# リトライ回数（デフォルト: 3）
+export STANDUP_CHATWORK_RETRY=3
+
+# リトライ間隔（秒、デフォルト: 2）
+export STANDUP_CHATWORK_RETRY_INTERVAL=2
+```
 
 ## コードレビューについて
 

--- a/skills/standup/chatwork-notify.sh
+++ b/skills/standup/chatwork-notify.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# chatwork-notify.sh — Chatwork API v2 へスタンドアップレポートを送信する
+#
+# 使用方法:
+#   STANDUP_CHATWORK_TOKEN=<token> STANDUP_CHATWORK_ROOM_ID=<room_id> \
+#     ./chatwork-notify.sh "レポートテキスト"
+#
+# 環境変数:
+#   STANDUP_CHATWORK_TOKEN   — Chatwork API トークン（必須）
+#   STANDUP_CHATWORK_ROOM_ID — 送信先ルーム ID（必須）
+
+set -euo pipefail
+
+# --- 引数 ---
+MESSAGE="${1:-}"
+if [ -z "$MESSAGE" ]; then
+  # 環境変数からも取得を試みる
+  MESSAGE="${STANDUP_REPORT:-}"
+fi
+
+if [ -z "$MESSAGE" ]; then
+  echo "エラー: 送信するメッセージが指定されていません。" >&2
+  echo "使用方法: $0 \"レポートテキスト\"" >&2
+  exit 1
+fi
+
+# --- 環境変数チェック ---
+if [ -z "${STANDUP_CHATWORK_TOKEN:-}" ]; then
+  echo "エラー: 環境変数 STANDUP_CHATWORK_TOKEN が設定されていません。" >&2
+  echo "設定方法: export STANDUP_CHATWORK_TOKEN='your_api_token'" >&2
+  exit 1
+fi
+
+if [ -z "${STANDUP_CHATWORK_ROOM_ID:-}" ]; then
+  echo "エラー: 環境変数 STANDUP_CHATWORK_ROOM_ID が設定されていません。" >&2
+  echo "設定方法: export STANDUP_CHATWORK_ROOM_ID='your_room_id'" >&2
+  exit 1
+fi
+
+# --- 定数 ---
+CHATWORK_API_BASE="https://api.chatwork.com/v2"
+RETRY_COUNT="${STANDUP_CHATWORK_RETRY:-3}"
+RETRY_INTERVAL="${STANDUP_CHATWORK_RETRY_INTERVAL:-2}"
+
+# --- 送信関数 ---
+send_to_chatwork() {
+  local token="$1"
+  local room_id="$2"
+  local message="$3"
+
+  local http_status
+  http_status=$(curl -s -o /tmp/chatwork_response.json -w "%{http_code}" \
+    -X POST \
+    -H "X-ChatWorkToken: ${token}" \
+    --data-urlencode "body=${message}" \
+    "${CHATWORK_API_BASE}/rooms/${room_id}/messages")
+
+  echo "$http_status"
+}
+
+# --- リトライループ ---
+attempt=0
+success=false
+
+while [ "$attempt" -lt "$RETRY_COUNT" ]; do
+  attempt=$((attempt + 1))
+
+  http_status=$(send_to_chatwork \
+    "$STANDUP_CHATWORK_TOKEN" \
+    "$STANDUP_CHATWORK_ROOM_ID" \
+    "$MESSAGE") || true
+
+  if [ "$http_status" = "200" ]; then
+    success=true
+    break
+  else
+    echo "警告: Chatwork への送信に失敗しました（試行 ${attempt}/${RETRY_COUNT}、HTTP ${http_status}）。" >&2
+    if [ -f /tmp/chatwork_response.json ]; then
+      echo "レスポンス: $(cat /tmp/chatwork_response.json)" >&2
+    fi
+
+    if [ "$attempt" -lt "$RETRY_COUNT" ]; then
+      echo "${RETRY_INTERVAL} 秒後にリトライします..." >&2
+      sleep "$RETRY_INTERVAL"
+    fi
+  fi
+done
+
+# --- 結果 ---
+if [ "$success" = true ]; then
+  echo "Chatwork への通知を送信しました（ルーム ID: ${STANDUP_CHATWORK_ROOM_ID}）"
+  exit 0
+else
+  echo "エラー: ${RETRY_COUNT} 回試行しましたが Chatwork への送信に失敗しました。" >&2
+  echo "以下を確認してください:" >&2
+  echo "  - STANDUP_CHATWORK_TOKEN が正しいか" >&2
+  echo "  - STANDUP_CHATWORK_ROOM_ID が正しいか" >&2
+  echo "  - ネットワーク接続が正常か" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 概要

Chatwork API v2 を使ったスタンドアップ通知機能を実装。日本市場向け特化機能（#44）の Sub-task 1（Issue #46）。

## 変更内容

- 作成: `skills/standup/chatwork-notify.sh` — Chatwork API v2 への POST 送信・リトライ・エラーハンドリング
- 変更: `skills/standup/SKILL.md` — `--notify chatwork` オプションと設定方法の追記
- 変更: `README.md` — Chatwork 連携セクションの追加

## テスト

- [x] `bash -n` シンタックスチェック PASS
- [x] 環境変数未設定時のエラーメッセージ確認
- [x] 人間によるコードレビュー

## 完了条件

- [x] `chatwork-notify.sh` が実行可能で `bash -n` チェックを通過する
- [x] 環境変数未設定時に分かりやすいエラーメッセージを表示する
- [x] Slack Webhook と同様の呼び出しインターフェースを持つ
- [x] `SKILL.md` に使用例が記載されている

---
このPRは Agent Team によって自動作成されました