### PR TITLE
feat: Microsoft Teams Webhook 通知対応 #58

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Claude Code で以下のように呼び出します：
 | `--export html` | HTML ファイルとしてエクスポート |
 | `--notify` | Slack/Discord Webhook に送信 |
 | `--notify chatwork` | Chatwork API v2 でルームに送信 |
+| `--notify teams` | Microsoft Teams Webhook に送信 |
 | `--template <path>` | カスタムテンプレートを使用 |
 
 ### 前提条件
@@ -100,6 +101,34 @@ export STANDUP_CHATWORK_ROOM_ID="123456"
 
 ```bash
 skills/standup/chatwork-notify.sh "レポートテキスト"
+```
+
+## Microsoft Teams 連携
+
+Microsoft Teams へのスタンドアップ通知を設定するには、以下の環境変数を設定してください。
+
+> **注意**: Microsoft Incoming Webhook は2026年末廃止予定のため、**Microsoft Workflows (Power Automate)** をご利用ください。
+
+```bash
+# Microsoft Workflows (Power Automate) の Webhook URL
+export STANDUP_TEAMS_WEBHOOK_URL="https://prod-xx.westus.logic.azure.com/..."
+```
+
+Webhook URL の取得方法：
+1. Teams チャンネル → 「...」→ 「Workflows」
+2. 「Post to a channel when a webhook request is received」を選択
+3. 生成された URL を環境変数に設定する
+
+設定後、`--notify teams` オプションで通知できます：
+
+```bash
+/standup evening --notify teams
+```
+
+スクリプトを直接呼び出すこともできます：
+
+```bash
+skills/standup/teams-notify.sh "レポートテキスト"
 ```
 
 ## セキュリティ上の注意

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -755,6 +755,58 @@ export STANDUP_CHATWORK_RETRY=3
 export STANDUP_CHATWORK_RETRY_INTERVAL=2
 ```
 
+## Microsoft Teams 通知の設定
+
+`--notify teams` オプションを使用する場合、以下の環境変数を設定してください。
+
+### 環境変数
+
+```bash
+export STANDUP_TEAMS_WEBHOOK_URL="https://prod-xx.westus.logic.azure.com/..."
+```
+
+### Webhook URL の取得方法
+
+Microsoft Incoming Webhook は2026年末に廃止予定のため、**Microsoft Workflows (Power Automate)** を使用してください。
+
+1. Teams チャンネルを開く
+2. チャンネル名横の「...」→ 「Workflows」をクリックする
+3. 「Post to a channel when a webhook request is received」テンプレートを選択する
+4. フロー名を設定し、送信先チャンネルを確認して「追加」をクリックする
+5. 生成された Webhook URL をコピーして `STANDUP_TEAMS_WEBHOOK_URL` に設定する
+
+### ペイロード形式の選択
+
+```bash
+# Adaptive Card 形式（リッチ表示、推奨）
+export STANDUP_TEAMS_PAYLOAD_TYPE="adaptive_card"
+
+# シンプルテキスト形式（フォールバック）
+export STANDUP_TEAMS_PAYLOAD_TYPE="text"  # デフォルト
+```
+
+### 使用例
+
+```bash
+export STANDUP_TEAMS_WEBHOOK_URL="https://prod-xx.westus.logic.azure.com/..."
+
+# Teams に通知する
+/standup evening --notify teams
+
+# 直接スクリプトを呼び出す場合
+skills/standup/teams-notify.sh "本日のスタンドアップレポート..."
+```
+
+### オプション環境変数
+
+```bash
+# リトライ回数（デフォルト: 3）
+export STANDUP_TEAMS_RETRY=3
+
+# リトライ間隔（秒、デフォルト: 2）
+export STANDUP_TEAMS_RETRY_INTERVAL=2
+```
+
 ## コードレビューについて
 
 - 差分に気になる点があれば軽く触れる

--- a/skills/standup/teams-notify.sh
+++ b/skills/standup/teams-notify.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# teams-notify.sh — Microsoft Teams Webhook へスタンドアップレポートを送信する
+#
+# 使用方法:
+#   STANDUP_TEAMS_WEBHOOK_URL=<webhook_url> ./teams-notify.sh "レポートテキスト"
+#
+# 環境変数:
+#   STANDUP_TEAMS_WEBHOOK_URL — Microsoft Workflows (Power Automate) Webhook URL（必須）
+#   STANDUP_TEAMS_PAYLOAD_TYPE — ペイロード形式: "adaptive_card" または "text"（デフォルト: "text"）
+#   STANDUP_TEAMS_RETRY        — リトライ回数（デフォルト: 3）
+#   STANDUP_TEAMS_RETRY_INTERVAL — リトライ間隔（秒、デフォルト: 2）
+#
+# Microsoft Workflows Webhook URL の取得方法:
+#   Teams チャンネル → Workflows → 「Post to a channel when a webhook request is received」
+#   → フローを作成 → 生成された URL を STANDUP_TEAMS_WEBHOOK_URL に設定する
+
+set -euo pipefail
+
+# --- 引数 ---
+MESSAGE="${1:-}"
+if [ -z "$MESSAGE" ]; then
+  # 環境変数からも取得を試みる
+  MESSAGE="${STANDUP_REPORT:-}"
+fi
+
+if [ -z "$MESSAGE" ]; then
+  echo "エラー: 送信するメッセージが指定されていません。" >&2
+  echo "使用方法: $0 \"レポートテキスト\"" >&2
+  exit 1
+fi
+
+# --- 環境変数チェック ---
+if [ -z "${STANDUP_TEAMS_WEBHOOK_URL:-}" ]; then
+  echo "エラー: 環境変数 STANDUP_TEAMS_WEBHOOK_URL が設定されていません。" >&2
+  echo "設定方法: export STANDUP_TEAMS_WEBHOOK_URL='https://prod-xx.westus.logic.azure.com/...'" >&2
+  echo "Webhook URL の取得: Teams チャンネル → Workflows → 「Post to a channel when a webhook request is received」" >&2
+  exit 1
+fi
+
+# --- 定数 ---
+PAYLOAD_TYPE="${STANDUP_TEAMS_PAYLOAD_TYPE:-text}"
+RETRY_COUNT="${STANDUP_TEAMS_RETRY:-3}"
+RETRY_INTERVAL="${STANDUP_TEAMS_RETRY_INTERVAL:-2}"
+
+# --- ペイロード生成関数 ---
+build_payload() {
+  local message="$1"
+  local payload_type="$2"
+
+  if [ "$payload_type" = "adaptive_card" ]; then
+    # Adaptive Card v1.4 形式
+    python3 -c "
+import json, sys
+message = sys.argv[1]
+payload = {
+    'type': 'message',
+    'attachments': [
+        {
+            'contentType': 'application/vnd.microsoft.card.adaptive',
+            'content': {
+                '\$schema': 'http://adaptivecards.io/schemas/adaptive-card.json',
+                'type': 'AdaptiveCard',
+                'version': '1.4',
+                'body': [
+                    {
+                        'type': 'TextBlock',
+                        'text': message,
+                        'wrap': True
+                    }
+                ]
+            }
+        }
+    ]
+}
+print(json.dumps(payload))
+" "$message" 2>/dev/null
+  else
+    # シンプルテキスト形式（フォールバック）
+    python3 -c "
+import json, sys
+message = sys.argv[1]
+print(json.dumps({'text': message}))
+" "$message" 2>/dev/null
+  fi
+}
+
+# --- 送信関数 ---
+send_to_teams() {
+  local webhook_url="$1"
+  local payload="$2"
+
+  local http_status
+  http_status=$(curl -s -o /tmp/teams_response.json -w "%{http_code}" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "$webhook_url")
+
+  echo "$http_status"
+}
+
+# --- ペイロード生成 ---
+PAYLOAD="$(build_payload "$MESSAGE" "$PAYLOAD_TYPE")"
+if [ -z "$PAYLOAD" ]; then
+  echo "エラー: ペイロードの生成に失敗しました。python3 が利用可能か確認してください。" >&2
+  exit 1
+fi
+
+# --- リトライループ ---
+attempt=0
+success=false
+
+while [ "$attempt" -lt "$RETRY_COUNT" ]; do
+  attempt=$((attempt + 1))
+
+  http_status=$(send_to_teams "$STANDUP_TEAMS_WEBHOOK_URL" "$PAYLOAD") || true
+
+  if [ "$http_status" = "200" ] || [ "$http_status" = "202" ]; then
+    success=true
+    break
+  else
+    echo "警告: Teams への送信に失敗しました（試行 ${attempt}/${RETRY_COUNT}、HTTP ${http_status}）。" >&2
+    if [ -f /tmp/teams_response.json ]; then
+      echo "レスポンス: $(cat /tmp/teams_response.json)" >&2
+    fi
+
+    if [ "$attempt" -lt "$RETRY_COUNT" ]; then
+      echo "${RETRY_INTERVAL} 秒後にリトライします..." >&2
+      sleep "$RETRY_INTERVAL"
+    fi
+  fi
+done
+
+# --- 結果 ---
+if [ "$success" = true ]; then
+  echo "Microsoft Teams への通知を送信しました"
+  exit 0
+else
+  echo "エラー: ${RETRY_COUNT} 回試行しましたが Teams への送信に失敗しました。" >&2
+  echo "以下を確認してください:" >&2
+  echo "  - STANDUP_TEAMS_WEBHOOK_URL が正しいか（Microsoft Workflows の URL を使用）" >&2
+  echo "  - ネットワーク接続が正常か" >&2
+  echo "  - Incoming Webhook（廃止予定）ではなく Workflows を使用しているか" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 概要

Microsoft Workflows (Power Automate) Webhook を使用した Teams 通知スクリプト `teams-notify.sh` を新規作成し、SKILL.md と README.md に設定方法を追記します。

## 変更内容

- 作成: `skills/standup/teams-notify.sh` — Teams Webhook 通知スクリプト（Adaptive Card / テキスト切り替え対応、リトライ3回）
- 変更: `skills/standup/SKILL.md` — Microsoft Teams 通知の設定セクションを追加
- 変更: `README.md` — Microsoft Teams 連携セクションを追加

## テスト方法

```bash
# シンタックスチェック
bash -n skills/standup/teams-notify.sh

# 環境変数未設定時のエラーメッセージ確認
STANDUP_TEAMS_WEBHOOK_URL="" bash skills/standup/teams-notify.sh "test"
```

期待される結果: `bash -n` がエラーなし、環境変数未設定時に分かりやすいエラーメッセージが出力される

## テスト結果

- [x] `bash -n` シンタックスチェック PASS
- [x] 環境変数未設定時のエラーメッセージ確認 PASS
- [ ] 人間によるコードレビュー

## 完了条件

- [x] `teams-notify.sh` が実行可能で `bash -n` チェックを通過する
- [x] 環境変数未設定時に分かりやすいエラーメッセージを表示する
- [x] chatwork-notify.sh と同様の呼び出しインターフェースを持つ
- [x] `SKILL.md` に使用例が記載されている
- [x] `README.md` に Teams 連携セクションが追加されている

Closes #58

---
🤖 このPRは Agent Team によって自動作成されました