### PR TITLE
ci: GitHub Actions ワークフローによる自動スキルテストの導入 #57

### DIFF
--- a/.github/workflows/skill-test.yml
+++ b/.github/workflows/skill-test.yml
@@ -1,0 +1,43 @@
+name: Skill Test
+
+on:
+  push:
+    paths:
+      - 'skills/**'
+      - '.github/workflows/skill-test.yml'
+  pull_request:
+    paths:
+      - 'skills/**'
+      - '.github/workflows/skill-test.yml'
+
+jobs:
+  syntax-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bash syntax check (all skill scripts)
+        run: |
+          find skills/ -name "*.sh" -exec bash -n {} \; && echo "All scripts passed syntax check"
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+      - name: Run shellcheck on skill scripts
+        run: |
+          find skills/ -name "*.sh" | xargs shellcheck --severity=warning
+
+  skill-md-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check SKILL.md files exist for each skill directory
+        run: |
+          for dir in skills/*/; do
+            if [ ! -f "${dir}SKILL.md" ]; then
+              echo "MISSING SKILL.md in ${dir}" && exit 1
+            fi
+          done
+          echo "All skill directories have SKILL.md"


### PR DESCRIPTION
## 概要

`.github/workflows/skill-test.yml` を新規作成し、PR マージ前に bash 構文チェック・shellcheck・SKILL.md 存在確認の3段階 CI を自動実行できるようにする。

## 変更内容

- 作成: `.github/workflows/skill-test.yml` — CI ワークフロー本体（3ジョブ構成）

## テスト方法

```bash
# ローカルでの構文チェック
bash -n skills/standup/team-summary.sh
bash -n skills/standup/chatwork-notify.sh
```

期待される結果: エラーなしで終了

## テスト結果

- [x] bash 構文チェック PASS（team-summary.sh / chatwork-notify.sh）
- [x] SKILL.md 存在確認 PASS（skills/standup/SKILL.md）
- [ ] 人間によるコードレビュー

## 完了条件

- [x] `.github/workflows/skill-test.yml` が作成されている
- [ ] `skills/` 配下の全 `.sh` ファイルが shellcheck WARNING 以下でパスする（CI 実行で確認）
- [x] 各スキルディレクトリに `SKILL.md` が存在することが CI で確認できる
- [ ] PR を作成すると自動で CI が走ることを GitHub Actions の実行ログで確認できる

Closes #57

---
🤖 このPRは Agent Team によって自動作成されました