### PR TITLE
feat: LINE WORKS Bot API v2 Webhook 通知対応 #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Claude Code で以下のように呼び出します：
 | `--export html` | HTML ファイルとしてエクスポート |
 | `--notify` | Slack/Discord Webhook に送信 |
 | `--notify chatwork` | Chatwork API v2 でルームに送信 |
+| `--notify lineworks` | LINE WORKS Bot API v2 でチャンネルに送信 |
 | `--template <path>` | カスタムテンプレートを使用 |
 
 ### 前提条件
@@ -100,6 +101,36 @@ export STANDUP_CHATWORK_ROOM_ID="123456"
 
 ```bash
 skills/standup/chatwork-notify.sh "レポートテキスト"
+```
+
+## LINE WORKS 連携
+
+LINE WORKS へのスタンドアップ通知を設定するには、以下の環境変数を設定してください。
+
+```bash
+# LINE WORKS Developer Console で取得した Client ID
+export STANDUP_LINE_WORKS_CLIENT_ID="your_client_id"
+
+# LINE WORKS Developer Console で取得した Client Secret
+export STANDUP_LINE_WORKS_CLIENT_SECRET="your_client_secret"
+
+# Bot 番号（Bot 設定画面で確認）
+export STANDUP_LINE_WORKS_BOT_NO="your_bot_no"
+
+# 送信先チャンネル ID
+export STANDUP_LINE_WORKS_CHANNEL_ID="your_channel_id"
+```
+
+設定後、`--notify lineworks` オプションで通知できます：
+
+```bash
+/standup evening --notify lineworks
+```
+
+スクリプトを直接呼び出すこともできます：
+
+```bash
+skills/standup/lineworks-notify.sh "レポートテキスト"
 ```
 
 ## セキュリティ上の注意

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -10,7 +10,8 @@ description: >
   Supports --template option to customize the report format with a Markdown template.
   Supports --notify option to post the report to Slack/Discord via Webhook URL.
   Supports --notify chatwork option to post the report to Chatwork via API v2.
-argument-hint: "[morning|evening] [hours] [repo_path1 repo_path2 ...] [--save] [--export html] [--open] [--notify [chatwork]] [--search <keyword>] [--summary weekly|monthly] [--template <path>]"
+  Supports --notify lineworks option to post the report to LINE WORKS via Bot API v2.
+argument-hint: "[morning|evening] [hours] [repo_path1 repo_path2 ...] [--save] [--export html] [--open] [--notify [chatwork|lineworks]] [--search <keyword>] [--summary weekly|monthly] [--template <path>]"
 ---
 
 # Standup Meeting Skill（朝会・夕会）
@@ -40,6 +41,7 @@ argument-hint: "[morning|evening] [hours] [repo_path1 repo_path2 ...] [--save] [
 - `--open` → エクスポート後にブラウザで自動オープンする（`--export html` と併用）
 - `--notify` → レポート完了後に Slack/Discord Webhook に投稿する
 - `--notify chatwork` → レポート完了後に Chatwork API v2 で指定ルームに投稿する（環境変数 `STANDUP_CHATWORK_TOKEN` と `STANDUP_CHATWORK_ROOM_ID` が必要）
+- `--notify lineworks` → レポート完了後に LINE WORKS Bot API v2 でチャンネルに投稿する（環境変数 `STANDUP_LINE_WORKS_CLIENT_ID`、`STANDUP_LINE_WORKS_CLIENT_SECRET`、`STANDUP_LINE_WORKS_BOT_NO`、`STANDUP_LINE_WORKS_CHANNEL_ID` が必要）
 - `--save` → スタンドアップレポートを `~/.standup-history/YYYY-MM-DD-morning-<repo>.json` または `~/.standup-history/YYYY-MM-DD-evening-<repo>.json` に保存する（`~` はそのユーザーの HOME ディレクトリ）
 - `--search <keyword>` → 過去のスタンドアップ履歴からキーワード検索して結果を表示する（朝会・夕会は実施しない）
 - `--summary weekly` → 過去7日分のスタンドアップ履歴を週次サマリーとして集計・表示する（朝会・夕会は実施しない）
@@ -753,6 +755,57 @@ export STANDUP_CHATWORK_RETRY=3
 
 # リトライ間隔（秒、デフォルト: 2）
 export STANDUP_CHATWORK_RETRY_INTERVAL=2
+```
+
+## LINE WORKS 通知の設定
+
+`--notify lineworks` オプションを使用する場合、以下の環境変数を設定してください。
+
+### 環境変数
+
+```bash
+export STANDUP_LINE_WORKS_CLIENT_ID="your_client_id"
+export STANDUP_LINE_WORKS_CLIENT_SECRET="your_client_secret"
+export STANDUP_LINE_WORKS_BOT_NO="your_bot_no"
+export STANDUP_LINE_WORKS_CHANNEL_ID="your_channel_id"
+```
+
+### Developer Console での設定手順
+
+1. [LINE WORKS Developer Console](https://developers.worksmobile.com/) にアクセスする
+2. アプリを作成し、「Bot」を追加する
+3. 「OAuth」設定で Client ID と Client Secret を取得する
+4. Bot の「Bot 番号」を確認する（URL または Bot 設定画面）
+5. 通知先チャンネルの ID を確認する（チャンネル詳細画面または API レスポンス）
+
+### チャンネル ID の確認方法
+
+LINE WORKS の Bot API で `/v1.0/bots/{botNo}/channels` エンドポイントを呼び出すと、
+チャンネル一覧と ID を取得できます。
+
+### 使用例
+
+```bash
+export STANDUP_LINE_WORKS_CLIENT_ID="abc123"
+export STANDUP_LINE_WORKS_CLIENT_SECRET="xyz789"
+export STANDUP_LINE_WORKS_BOT_NO="12345"
+export STANDUP_LINE_WORKS_CHANNEL_ID="67890"
+
+# LINE WORKS に通知する
+/standup evening --notify lineworks
+
+# 直接スクリプトを呼び出す場合
+skills/standup/lineworks-notify.sh "本日のスタンドアップレポート..."
+```
+
+### オプション環境変数
+
+```bash
+# リトライ回数（デフォルト: 3）
+export STANDUP_LINE_WORKS_RETRY=3
+
+# リトライ間隔（秒、デフォルト: 2）
+export STANDUP_LINE_WORKS_RETRY_INTERVAL=2
 ```
 
 ## コードレビューについて

--- a/skills/standup/lineworks-notify.sh
+++ b/skills/standup/lineworks-notify.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# lineworks-notify.sh — LINE WORKS Bot API v2 へスタンドアップレポートを送信する
+#
+# 使用方法:
+#   STANDUP_LINE_WORKS_CLIENT_ID=<client_id> \
+#   STANDUP_LINE_WORKS_CLIENT_SECRET=<client_secret> \
+#   STANDUP_LINE_WORKS_BOT_NO=<bot_no> \
+#   STANDUP_LINE_WORKS_CHANNEL_ID=<channel_id> \
+#     ./lineworks-notify.sh "レポートテキスト"
+#
+# 環境変数:
+#   STANDUP_LINE_WORKS_CLIENT_ID     — LINE WORKS Developer Console の Client ID（必須）
+#   STANDUP_LINE_WORKS_CLIENT_SECRET — LINE WORKS Developer Console の Client Secret（必須）
+#   STANDUP_LINE_WORKS_BOT_NO        — Bot 番号（必須）
+#   STANDUP_LINE_WORKS_CHANNEL_ID    — 送信先チャンネル ID（必須）
+
+set -euo pipefail
+
+# --- 引数 ---
+MESSAGE="${1:-}"
+if [ -z "$MESSAGE" ]; then
+  # 環境変数からも取得を試みる
+  MESSAGE="${STANDUP_REPORT:-}"
+fi
+
+if [ -z "$MESSAGE" ]; then
+  echo "エラー: 送信するメッセージが指定されていません。" >&2
+  echo "使用方法: $0 \"レポートテキスト\"" >&2
+  exit 1
+fi
+
+# --- 環境変数チェック ---
+if [ -z "${STANDUP_LINE_WORKS_CLIENT_ID:-}" ]; then
+  echo "エラー: 環境変数 STANDUP_LINE_WORKS_CLIENT_ID が設定されていません。" >&2
+  echo "設定方法: export STANDUP_LINE_WORKS_CLIENT_ID='your_client_id'" >&2
+  exit 1
+fi
+
+if [ -z "${STANDUP_LINE_WORKS_CLIENT_SECRET:-}" ]; then
+  echo "エラー: 環境変数 STANDUP_LINE_WORKS_CLIENT_SECRET が設定されていません。" >&2
+  echo "設定方法: export STANDUP_LINE_WORKS_CLIENT_SECRET='your_client_secret'" >&2
+  exit 1
+fi
+
+if [ -z "${STANDUP_LINE_WORKS_BOT_NO:-}" ]; then
+  echo "エラー: 環境変数 STANDUP_LINE_WORKS_BOT_NO が設定されていません。" >&2
+  echo "設定方法: export STANDUP_LINE_WORKS_BOT_NO='your_bot_no'" >&2
+  exit 1
+fi
+
+if [ -z "${STANDUP_LINE_WORKS_CHANNEL_ID:-}" ]; then
+  echo "エラー: 環境変数 STANDUP_LINE_WORKS_CHANNEL_ID が設定されていません。" >&2
+  echo "設定方法: export STANDUP_LINE_WORKS_CHANNEL_ID='your_channel_id'" >&2
+  exit 1
+fi
+
+# --- 定数 ---
+LINE_WORKS_AUTH_URL="https://auth.worksmobile.com/oauth2/v2.0/token"
+LINE_WORKS_API_BASE="https://www.worksapis.com/v1.0"
+RETRY_COUNT="${STANDUP_LINE_WORKS_RETRY:-3}"
+RETRY_INTERVAL="${STANDUP_LINE_WORKS_RETRY_INTERVAL:-2}"
+
+# --- アクセストークン取得関数 ---
+get_access_token() {
+  local client_id="$1"
+  local client_secret="$2"
+
+  local response
+  response=$(curl -s -X POST "${LINE_WORKS_AUTH_URL}" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "grant_type=client_credentials" \
+    --data-urlencode "client_id=${client_id}" \
+    --data-urlencode "client_secret=${client_secret}" \
+    --data-urlencode "scope=bot") || {
+    echo ""
+    return 1
+  }
+
+  # access_token フィールドを抽出する（python3 は依存を避けるため grep/sed で処理）
+  echo "$response" | grep -o '"access_token":"[^"]*"' | sed 's/"access_token":"//;s/"//'
+}
+
+# --- メッセージ送信関数 ---
+send_to_lineworks() {
+  local access_token="$1"
+  local bot_no="$2"
+  local channel_id="$3"
+  local message="$4"
+
+  local payload
+  payload=$(printf '{"content":{"type":"text","text":"%s"}}' \
+    "$(printf '%s' "$message" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' | tr -d '\n' | sed 's/\\n$//')")
+
+  local http_status
+  http_status=$(curl -s -o /tmp/lineworks_response.json -w "%{http_code}" \
+    -X POST \
+    -H "Authorization: Bearer ${access_token}" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "${LINE_WORKS_API_BASE}/bots/${bot_no}/channels/${channel_id}/messages")
+
+  echo "$http_status"
+}
+
+# --- メイン処理: アクセストークン取得 ---
+ACCESS_TOKEN=""
+token_attempt=0
+while [ "$token_attempt" -lt "$RETRY_COUNT" ]; do
+  token_attempt=$((token_attempt + 1))
+  ACCESS_TOKEN=$(get_access_token \
+    "$STANDUP_LINE_WORKS_CLIENT_ID" \
+    "$STANDUP_LINE_WORKS_CLIENT_SECRET") || true
+
+  if [ -n "$ACCESS_TOKEN" ]; then
+    break
+  fi
+
+  echo "警告: アクセストークンの取得に失敗しました（試行 ${token_attempt}/${RETRY_COUNT}）。" >&2
+  if [ "$token_attempt" -lt "$RETRY_COUNT" ]; then
+    echo "${RETRY_INTERVAL} 秒後にリトライします..." >&2
+    sleep "$RETRY_INTERVAL"
+  fi
+done
+
+if [ -z "$ACCESS_TOKEN" ]; then
+  echo "エラー: アクセストークンの取得に失敗しました。" >&2
+  echo "以下を確認してください:" >&2
+  echo "  - STANDUP_LINE_WORKS_CLIENT_ID が正しいか" >&2
+  echo "  - STANDUP_LINE_WORKS_CLIENT_SECRET が正しいか" >&2
+  echo "  - ネットワーク接続が正常か" >&2
+  exit 1
+fi
+
+# --- メイン処理: メッセージ送信リトライループ ---
+attempt=0
+success=false
+
+while [ "$attempt" -lt "$RETRY_COUNT" ]; do
+  attempt=$((attempt + 1))
+
+  http_status=$(send_to_lineworks \
+    "$ACCESS_TOKEN" \
+    "$STANDUP_LINE_WORKS_BOT_NO" \
+    "$STANDUP_LINE_WORKS_CHANNEL_ID" \
+    "$MESSAGE") || true
+
+  if [ "$http_status" = "200" ] || [ "$http_status" = "201" ]; then
+    success=true
+    break
+  else
+    echo "警告: LINE WORKS への送信に失敗しました（試行 ${attempt}/${RETRY_COUNT}、HTTP ${http_status}）。" >&2
+    if [ -f /tmp/lineworks_response.json ]; then
+      echo "レスポンス: $(cat /tmp/lineworks_response.json)" >&2
+    fi
+
+    if [ "$attempt" -lt "$RETRY_COUNT" ]; then
+      echo "${RETRY_INTERVAL} 秒後にリトライします..." >&2
+      sleep "$RETRY_INTERVAL"
+    fi
+  fi
+done
+
+# --- 結果 ---
+if [ "$success" = true ]; then
+  echo "LINE WORKS への通知を送信しました（チャンネル ID: ${STANDUP_LINE_WORKS_CHANNEL_ID}）"
+  exit 0
+else
+  echo "エラー: ${RETRY_COUNT} 回試行しましたが LINE WORKS への送信に失敗しました。" >&2
+  echo "以下を確認してください:" >&2
+  echo "  - STANDUP_LINE_WORKS_CLIENT_ID が正しいか" >&2
+  echo "  - STANDUP_LINE_WORKS_CLIENT_SECRET が正しいか" >&2
+  echo "  - STANDUP_LINE_WORKS_BOT_NO が正しいか" >&2
+  echo "  - STANDUP_LINE_WORKS_CHANNEL_ID が正しいか" >&2
+  echo "  - ネットワーク接続が正常か" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 概要

LINE WORKS Bot API v2 を使ったスタンドアップ通知機能を追加します。日本市場向け特化機能（#44）の Sub-task 2 です。

## 変更内容

- 作成: `skills/standup/lineworks-notify.sh` — LINE WORKS Bot API v2 通知スクリプト（OAuth2 Client Credentials フロー、リトライ3回）
- 変更: `skills/standup/SKILL.md` — `--notify lineworks` オプションの説明と設定セクションを追加
- 変更: `README.md` — LINE WORKS 連携セクションとオプションテーブルを追加

## テスト方法

```bash
# シンタックスチェック
bash -n skills/standup/lineworks-notify.sh

# 環境変数未設定時のエラーメッセージ確認
STANDUP_LINE_WORKS_CLIENT_ID="" bash skills/standup/lineworks-notify.sh "test"
```

期待される結果: `bash -n` がエラーなし、環境変数未設定時に分かりやすいエラーメッセージが出力される

## テスト結果

- [x] `bash -n` シンタックスチェック PASS
- [x] 環境変数未設定時のエラーメッセージ確認 PASS
- [x] メッセージ未設定時のエラーメッセージ確認 PASS
- [ ] 人間によるコードレビュー

## 完了条件

- [x] `lineworks-notify.sh` が実行可能で `bash -n` チェックを通過する
- [x] 環境変数未設定時に分かりやすいエラーメッセージを表示する
- [x] chatwork-notify.sh と同様の呼び出しインターフェースを持つ
- [x] `SKILL.md` に使用例が記載されている
- [x] `README.md` に LINE WORKS 連携セクションが追加されている

Closes #48

---
🤖 このPRは Agent Team によって自動作成されました